### PR TITLE
Declare dependencies

### DIFF
--- a/bibliograph/core/tests.py
+++ b/bibliograph/core/tests.py
@@ -5,7 +5,7 @@ from zope.component import testing
 from zope.component import provideUtility
 from zope.component import getUtility
 
-from zope.app.schema.vocabulary import IVocabularyFactory
+from zope.schema.interfaces import IVocabularyFactory
 
 from bibliograph.core.vocabulary import BibFormatVocabularyFactory
 

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,11 @@ setup(name='bibliograph.core',
       namespace_packages=['bibliograph'],
       include_package_data=True,
       zip_safe=False,
-      install_requires=['setuptools'],
-      tests_require=['zope.testing'],
+      install_requires=[
+          'setuptools',
+          'zope.interface',
+          'zope.schema',
+      ],
+      tests_require=['zope.testing<4.2', 'zope.component'],
       entry_points=entry_points,
       )


### PR DESCRIPTION
zope.testing removed doctestunit in 4.2
zope.app.schema.vocabulary.IVocabularyFactory
was moved to zope.schema.interfaces.IVocabularyFactory